### PR TITLE
Add support for max-age in the koa static middleware through settings

### DIFF
--- a/packages/roc-package-web-app/app/server/index.js
+++ b/packages/roc-package-web-app/app/server/index.js
@@ -55,10 +55,17 @@ export default function createServer(options = {}, beforeUserMiddlewares = []) {
 
     const makeServe = (toServe = []) => {
         toServe = [].concat(toServe);
+
+        const staticSettings = process.env.NODE_ENV === 'production' ? runtimeSettings.koa.staticServe : {};
+
         for (const path of toServe) {
-            // We use defer here to no try to fetch a file if we have set something on body, something that is done in
+            server.use(serve(path, {
+            // We use defer as default here to no try to fetch a file
+            // if we have set something on body, something that is done in
             // redirect. This because https://github.com/koajs/send/issues/51
-            server.use(serve(path, { defer: true }));
+                defer: true,
+                ...staticSettings
+            }));
         }
     };
 

--- a/packages/roc-package-web-app/src/config/roc.config.js
+++ b/packages/roc-package-web-app/src/config/roc.config.js
@@ -27,6 +27,9 @@ export default {
                 trailingSlashes: {
                     enabled: true,
                     defer: true
+                },
+                staticServe: {
+                    maxage: 60000
                 }
             }
         }

--- a/packages/roc-package-web-app/src/config/roc.config.meta.js
+++ b/packages/roc-package-web-app/src/config/roc.config.meta.js
@@ -42,6 +42,9 @@ export default {
                     trailingSlashes: {
                         enabled: 'Set to true to enforce trailing slashes, false to remove them and null for no rule.',
                         defer: 'If this should be performed after looking for a file on disk.'
+                    },
+                    staticServe: {
+                        maxage: 'Browser cache max-age in milliseconds. Production only.'
                     }
                 }
             }


### PR DESCRIPTION
- Only applies in production
- Forces defer to true, because of the current bug (comment)
- Also forwards other static middleware properties as an unsupported escape hatch. It is really important that we find a good solution or pattern to this in general.
