### PR TITLE
Adds missing dependency to roc-package-webpack-dev.

### DIFF
--- a/packages/roc-package-web-app-dev/package.json
+++ b/packages/roc-package-web-app-dev/package.json
@@ -30,6 +30,7 @@
     "roc": "^1.0.0-rc",
     "roc-package-base-dev": "^1.0.0-alpha",
     "roc-package-web-app": "^1.0.0-alpha",
+    "roc-package-webpack-dev": "^1.0.0-alpha",
     "roc-package-webpack-node-dev": "^1.0.0-alpha",
     "roc-package-webpack-web-dev": "^1.0.0-alpha",
     "roc-plugin-browsersync": "^1.0.0-alpha",


### PR DESCRIPTION
Used in https://github.com/rocjs/roc-package-web-app/blob/bug/add-missing-dep/packages/roc-package-web-app-dev/src/builder/index.js#L3
