### PR TITLE
Pass the koa server to koaMiddlewares

### DIFF
--- a/extensions/roc-package-web-app/src/app/createServer.js
+++ b/extensions/roc-package-web-app/src/app/createServer.js
@@ -55,7 +55,7 @@ export default function createServer(options = {}, beforeUserMiddlewares = [], {
 
     if (hasKoaMiddlewares) {
         // eslint-disable-next-line
-        const middlewares = koaMiddlewares.default(runtimeSettings);
+        const middlewares = koaMiddlewares.default(runtimeSettings, { server });
         middlewares.forEach((middleware) => server.use(middleware));
     }
 


### PR DESCRIPTION
Allows the middlewares to hook into koa's events.

For example, we have a middleware that listens to `app.on("error", () => { do stuff })`.
