### PR TITLE
Remove koa-mount

### DIFF
--- a/extensions/roc-package-web-app-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-app-dev/src/config/roc.config.meta.js
@@ -9,6 +9,16 @@ import {
 export default {
     settings: {
         build: {
+            path: {
+                override: 'roc-package-webpack-dev',
+                validator: required(notEmpty((value, info) => {
+                    if (value && value.charAt(0) !== '/') {
+                        return 'Must start with "/"!';
+                    }
+
+                    return isPath(value, info);
+                })),
+            },
             targets: {
                 override: 'roc-abstract-package-base-dev',
                 validator: isArray(/^web|node$/i),

--- a/extensions/roc-package-web-app/package.json
+++ b/extensions/roc-package-web-app/package.json
@@ -41,7 +41,6 @@
     "koa-helmet": "~0.3.0",
     "koa-logger": "~1.3.0",
     "koa-lowercase-path": "~1.0.0",
-    "koa-mount": "~1.3.0",
     "koa-normalize-path": "~1.0.0",
     "koa-remove-trailing-slashes": "~1.0.0",
     "koa-static": "~2.0.0",

--- a/extensions/roc-package-web-app/src/app/basepathSupport.js
+++ b/extensions/roc-package-web-app/src/app/basepathSupport.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+
+/*
+ Implementation based on koa-mount
+*/
+export default function basepathSupport(basepath) {
+    assert(basepath.charAt(0) === '/', `The basepath must start with "/", was ${basepath}`);
+
+    const trailingSlash = basepath.slice(-1) === '/';
+
+    function matcher(path) {
+        if (path.indexOf(basepath) !== 0) {
+            return false;
+        }
+
+        const newPath = path.replace(basepath, '') || '/';
+
+        if (trailingSlash) {
+            return newPath;
+        }
+
+        if (newPath.charAt(0) !== '/') {
+            return false;
+        }
+
+        return newPath;
+    }
+
+    return function* (next) {
+        // Do nothing if the basepath is /
+        if (basepath === '/') {
+            return yield next;
+        }
+
+        const newPath = matcher(this.path);
+        if (newPath) {
+            this.path = newPath;
+            return yield next;
+        }
+
+        // If the path does not match Koa will render a default 404 Not Found page.
+        return undefined;
+    };
+}

--- a/extensions/roc-package-web-app/src/roc/index.js
+++ b/extensions/roc-package-web-app/src/roc/index.js
@@ -26,7 +26,6 @@ export default {
         uses: generateDependencies(packageJSON, [
             'koa',
             'koa-static',
-            'koa-mount',
             'koa-errors',
             'koa-helmet',
             'koa-etag',


### PR DESCRIPTION
Removes `koa-mount`, adds middleware that provides the same functionality.

We where not really using the main functionality of it, to be able to run multiple Koa applications on the same port. The added middleware gives us the feature that we want, being able to run the application on a specified basepath.

This change is done primarily to make it easier to interact with the Koa application, for instance when using `koa-session`.