### PR TITLE
Update to v1.0.0-beta3 of roc-package-webpack-node-dev

### DIFF
--- a/extensions/roc-package-web-app-dev/package.json
+++ b/extensions/roc-package-web-app-dev/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "roc": "^1.0.0-rc.12",
     "roc-package-webpack-dev": "^1.0.0-beta.2",
-    "roc-package-webpack-node-dev": "^1.0.0-beta.2",
+    "roc-package-webpack-node-dev": "^1.0.0-beta.3",
     "roc-package-webpack-web-dev": "^1.0.0-beta.3",
     "roc-plugin-browsersync": "^1.0.0-beta.2",
     "roc-plugin-style-css": "^1.0.0-beta.3",


### PR DESCRIPTION
Update to v1.0.0-beta3 of roc-package-webpack-node-dev so that I can start using https://github.com/rocjs/roc-package-webpack-node/pull/9