### PR TITLE
Made `trailingSlashes`-config not required

### DIFF
--- a/extensions/roc-package-web-app/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-app/src/config/roc.config.meta.js
@@ -80,7 +80,7 @@ export default {
                     },
                     defer: {
                         description: 'If this should be performed after looking for a file on disk.',
-                        validator: isBoolean,
+                        validator: required(isBoolean),
                     },
                 },
                 staticServe: {

--- a/extensions/roc-package-web-app/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-app/src/config/roc.config.meta.js
@@ -76,11 +76,11 @@ export default {
                     enabled: {
                         description: 'Set to true to enforce trailing slashes, false to remove them and ' +
                             'null for no rule.',
-                        validator: required(isBoolean),
+                        validator: isBoolean,
                     },
                     defer: {
                         description: 'If this should be performed after looking for a file on disk.',
-                        validator: required(isBoolean),
+                        validator: isBoolean,
                     },
                 },
                 staticServe: {


### PR DESCRIPTION
In order to disable `trailingSlashes` middleware one must be able to set config options `enable=null`.

[The docs](https://github.com/rocjs/roc-package-web-app/blob/master/extensions/roc-package-web-app/docs/Settings.md#trailingslashes) states that null is a valid option, but the current `required(isBoolean)` forbids `null` as a valid option.

